### PR TITLE
Fixing JSX MD formatting

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -892,12 +892,12 @@ export const Title = ({ children, className }) =>
 
 
 //or if you need div element 
+export const Title = ({ children, className }) =>
 <Typography as="div" variant="T30" className={className}>
   {children}
 </Typography>
-
-
 ```
+
 <br/>
 
 


### PR DESCRIPTION
# Before (closing tag isn't highlighted)
![image](https://user-images.githubusercontent.com/3920806/213473546-eca7934e-e2da-430a-a4bb-dc3b1fc7bed4.png)

# After
![image](https://user-images.githubusercontent.com/3920806/213473770-16e7df4f-55e3-47b3-bc0b-43bfcb0c50b1.png)
